### PR TITLE
Cleanup Galaxy Docker Image (compose-v2)

### DIFF
--- a/compose-v2/galaxy-server/Dockerfile
+++ b/compose-v2/galaxy-server/Dockerfile
@@ -108,15 +108,14 @@ ENV GALAXY_USER=galaxy \
 
 ENV GALAXY_CONFIG_FILE=$GALAXY_CONFIG_DIR/galaxy.yml
 
-COPY --from=build_galaxy ${GALAXY_ROOT} ${GALAXY_ROOT}
-COPY --from=build_miniconda ${GALAXY_CONFIG_TOOL_DEPENDENCY_DIR} ${GALAXY_CONFIG_TOOL_DEPENDENCY_DIR}
-COPY --from=build_miniconda ${GALAXY_HOME} ${GALAXY_HOME}
-COPY --from=build_miniconda /etc/profile.d/conda.sh /etc/profile.d/conda.sh
-
 # Set permissions
 RUN groupadd -r $GALAXY_USER -g $GALAXY_GID \
-    && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER \
-    && chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_HOME $GALAXY_ROOT $GALAXY_CONFIG_TOOL_DEPENDENCY_DIR /etc/profile.d/conda.sh
+    && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER
+
+COPY --chown=$GALAXY_USER:$GALAXY_USER --from=build_galaxy ${GALAXY_ROOT} ${GALAXY_ROOT}
+COPY --chown=$GALAXY_USER:$GALAXY_USER --from=build_miniconda ${GALAXY_CONFIG_TOOL_DEPENDENCY_DIR} ${GALAXY_CONFIG_TOOL_DEPENDENCY_DIR}
+COPY --chown=$GALAXY_USER:$GALAXY_USER --from=build_miniconda ${GALAXY_HOME} ${GALAXY_HOME}
+COPY --chown=$GALAXY_USER:$GALAXY_USER --from=build_miniconda /etc/profile.d/conda.sh /etc/profile.d/conda.sh
 
 COPY ./files/job_conf.xml ${GALAXY_CONFIG_DIR}/job_conf.xml
 COPY ./files/galaxy.yml /${GALAXY_CONFIG_DIR}/galaxy.yml

--- a/compose-v2/galaxy-server/Dockerfile
+++ b/compose-v2/galaxy-server/Dockerfile
@@ -58,7 +58,9 @@ RUN apt update && apt install --no-install-recommends python-dev python-pip -y &
     && pip install cheetah \
     && deactivate \
     && find / -name '*.pyc' -delete | true \
-    && rm -rf client contrib doc test test-data .venv/lib/node_modules .venv/src/node-v10.13.0-linux-x64 \
+    && rm -rf .ci .circleci .coveragerc .gitignore .travis.yml CITATION CODE_OF_CONDUCT.md CONTRIBUTING.md CONTRIBUTORS.md \
+              LICENSE.txt Makefile README.rst SECURITY_POLICY.md pytest.ini tox.ini \
+              client contrib doc test test-data .venv/lib/node_modules .venv/src/node-v10.13.0-linux-x64 \
               .venv/include/node .venv/bin/node .venv/bin/nodeenv
 
 FROM ubuntu:19.10 as final

--- a/compose-v2/galaxy-server/Dockerfile
+++ b/compose-v2/galaxy-server/Dockerfile
@@ -30,6 +30,7 @@ RUN groupadd -r $GALAXY_USER -g $GALAXY_GID \
     && chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_HOME
 
 FROM build_base as build_miniconda
+COPY ./files/common_cleanup.sh /usr/bin/common_cleanup.sh
 # Install Miniconda
 RUN curl -s -L "https://repo.anaconda.com/miniconda/Miniconda2-${MINICONDA_VERSION}-Linux-x86_64.sh" > ~/miniconda.sh \
     && /bin/bash ~/miniconda.sh -b -p $GALAXY_CONDA_PREFIX \
@@ -43,9 +44,10 @@ RUN curl -s -L "https://repo.anaconda.com/miniconda/Miniconda2-${MINICONDA_VERSI
     && conda config --add channels conda-forge \
     && conda install virtualenv pip ephemeris \
     && conda clean --packages -t -i \
-    && find / -name '*.pyc' -delete | true
+    && /usr/bin/common_cleanup.sh
 
 FROM build_base as build_galaxy
+COPY ./files/common_cleanup.sh /usr/bin/common_cleanup.sh
 # Install Galaxy
 RUN apt update && apt install --no-install-recommends python-dev python-pip -y && rm -rf /var/lib/apt/lists/* \
     && mkdir "${GALAXY_ROOT}" \
@@ -57,18 +59,21 @@ RUN apt update && apt install --no-install-recommends python-dev python-pip -y &
     && pip uninstall cheetah -y \
     && pip install cheetah \
     && deactivate \
-    && find / -name '*.pyc' -delete | true \
     && rm -rf .ci .circleci .coveragerc .gitignore .travis.yml CITATION CODE_OF_CONDUCT.md CONTRIBUTING.md CONTRIBUTORS.md \
               LICENSE.txt Makefile README.rst SECURITY_POLICY.md pytest.ini tox.ini \
               client contrib doc test test-data .venv/lib/node_modules .venv/src/node-v10.13.0-linux-x64 \
-              .venv/include/node .venv/bin/node .venv/bin/nodeenv
+              .venv/include/node .venv/bin/node .venv/bin/nodeenv \
+    && /usr/bin/common_cleanup.sh
 
 FROM ubuntu:19.10 as final
+COPY ./files/common_cleanup.sh /usr/bin/common_cleanup.sh
 
 # Install HTCondor
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt install --no-install-recommends htcondor -y \
-    && rm /etc/condor/condor_config.local
+    && rm /etc/condor/condor_config.local \
+    && find / -name '*.pyc' -delete | true \
+    && /usr/bin/common_cleanup.sh
 
 # Install CVMFS
 RUN apt update \
@@ -78,15 +83,16 @@ RUN apt update \
     && rm -f cvmfs-release-latest_all.deb \
     && apt update \
     && apt install --no-install-recommends cvmfs -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir /srv/cvmfs
+    && mkdir /srv/cvmfs \
+    && /usr/bin/common_cleanup.sh
+
 COPY files/cvmfs/default.local /etc/cvmfs/default.local
 COPY files/cvmfs/galaxyproject.org.conf /etc/cvmfs/domain.d/galaxyproject.org.conf
 COPY files/cvmfs/data.galaxyproject.org.pub /etc/cvmfs/keys/data.galaxyproject.org.pub
 
 # Install remaining dependencies
 RUN apt update && apt install --no-install-recommends ca-certificates netcat libpq-dev mercurial libgomp1  -y \
-    && rm -rf /var/lib/apt/lists/*
+    && /usr/bin/common_cleanup.sh
 
 ENV EXPORT_DIR=/export \
     GALAXY_ROOT=/galaxy \
@@ -112,7 +118,8 @@ ENV GALAXY_CONFIG_FILE=$GALAXY_CONFIG_DIR/galaxy.yml
 
 # Set permissions
 RUN groupadd -r $GALAXY_USER -g $GALAXY_GID \
-    && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER
+    && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER \
+    && /usr/bin/common_cleanup.sh
 
 COPY --chown=$GALAXY_USER:$GALAXY_USER --from=build_galaxy ${GALAXY_ROOT} ${GALAXY_ROOT}
 COPY --chown=$GALAXY_USER:$GALAXY_USER --from=build_miniconda ${GALAXY_CONFIG_TOOL_DEPENDENCY_DIR} ${GALAXY_CONFIG_TOOL_DEPENDENCY_DIR}

--- a/compose-v2/galaxy-server/files/common_cleanup.sh
+++ b/compose-v2/galaxy-server/files/common_cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -x
+
+find / -name '*.pyc' -delete
+find / -name '*.log' -delete
+find / -name '.cache' -delete
+rm -rf /var/lib/apt/lists/*
+rm -rf /var/cache/*


### PR DESCRIPTION
* Use `COPY --chown` while copying from other layers instead of doing a `RUN chown`. This reduced the image size by 1GB (the old "non-chwoned" files remained in an older layer)
* Remove unnecessary files from galaxy root (we don't need README etc to run Galaxy in Docker)
* Run cleanup script after each RUN. This script removes log files, caches etc.

By this the compressed image size has been shrunken from 655MB to 352MB!