### PR TITLE
Run workflow-tests in parallel & refactor test matrix

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -53,14 +53,16 @@ jobs:
           - name: bioblend
             files: -f docker-compose.test.yml -f docker-compose.test.bioblend.yml
             exit-from: galaxy-bioblend-test
-          - name: workflow_mapping_by_sequencing
-            files: -f docker-compose.test.yml -f docker-compose.test.workflows.yml
-            exit-from: galaxy-workflow-test
-            workflow: training/variant-analysis/mapping-by-sequencing/mapping_by_sequencing.ga
+            second_run: "true"
           - name: workflow_ard
             files: -f docker-compose.test.yml -f docker-compose.test.workflows.yml
             exit-from: galaxy-workflow-test
             workflow: sklearn/ard/ard.ga
+            second_run: "true"
+          - name: workflow_mapping_by_sequencing
+            files: -f docker-compose.test.yml -f docker-compose.test.workflows.yml
+            exit-from: galaxy-workflow-test
+            workflow: training/variant-analysis/mapping-by-sequencing/mapping_by_sequencing.ga
           - name: workflow_GC-lite
             files: -f docker-compose.test.yml -f docker-compose.test.workflows.yml
             exit-from: galaxy-workflow-test
@@ -98,11 +100,13 @@ jobs:
           name: ${{ matrix.infrastructure.name }}_${{ matrix.test.name }}_first-run
           path: ./compose-v2/export/galaxy/database
       - name: Clean up after first run
+        if: matrix.test.second_run == 'true'
         run: |
           sudo rm -rf export/postgres
           sudo rm -rf export/galaxy/database
         working-directory: ./compose-v2
       - name: Run tests a second time
+        if: matrix.test.second_run == 'true'
         run: |
           docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
           test_exit_code=$?
@@ -112,11 +116,11 @@ jobs:
         continue-on-error: false
         timeout-minutes: 120
       - name: Allow upload-artifact read access
-        if: failure()
+        if: failure() && matrix.test.second_run == 'true'
         run: sudo chmod -R +r ./compose-v2/export/galaxy/database
       - name: Save artifacts for debugging a failed test
         uses: actions/upload-artifact@v1
-        if: failure()
+        if: failure() && matrix.test.second_run == 'true'
         with:
           name: ${{ matrix.infrastructure.name }}_${{ matrix.test.name }}_first-run
           path: ./compose-v2/export/galaxy/database

--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -44,19 +44,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        case:
+        infrastructure:
+          - name: galaxy-base
+            files: -f docker-compose.yml
+          - name: galaxy-htcondor
+            files: -f docker-compose.yml -f docker-compose.htcondor.yml
+        test:
           - name: bioblend
-            files: -f docker-compose.yml -f docker-compose.test.yml -f docker-compose.test.bioblend.yml
+            files: -f docker-compose.test.yml -f docker-compose.test.bioblend.yml
             exit-from: galaxy-bioblend-test
-          - name: bioblend-htcondor
-            files: -f docker-compose.yml -f docker-compose.htcondor.yml -f docker-compose.test.yml -f docker-compose.test.bioblend.yml
-            exit-from: galaxy-bioblend-test
-          - name: workflows
-            files: -f docker-compose.yml -f docker-compose.test.yml -f docker-compose.test.workflows.yml
+          - name: workflow_mapping_by_sequencing
+            files: -f docker-compose.test.yml -f docker-compose.test.workflows.yml
             exit-from: galaxy-workflow-test
-          - name: workflows-htcondor
-            files: -f docker-compose.yml -f docker-compose.htcondor.yml -f docker-compose.test.yml -f docker-compose.test.workflows.yml
+            workflow: training/variant-analysis/mapping-by-sequencing/mapping_by_sequencing.ga
+          - name: workflow_ard
+            files: -f docker-compose.test.yml -f docker-compose.test.workflows.yml
             exit-from: galaxy-workflow-test
+            workflow: sklearn/ard/ard.ga
+          - name: workflow_GC-lite
+            files: -f docker-compose.test.yml -f docker-compose.test.workflows.yml
+            exit-from: galaxy-workflow-test
+            workflow: GraphClust2/GC-lite.ga
       fail-fast: false
     steps:
       - name: Checkout
@@ -66,13 +74,16 @@ jobs:
       - name: Master branch - Set image to to 'latest'
         if: github.ref == 'refs/heads/master'
         run: echo "::set-env name=IMAGE_TAG::latest"
+      - name: Set WORKFLOWS env for worfklows-test
+        if: matrix.test.workflow
+        run: echo "::set-env name=WORKFLOWS::${{ matrix.workflows }}"
       - name: Run tests for the first time
         run: |
-          docker-compose ${{ matrix.case.files }} pull
-          docker-compose ${{ matrix.case.files }} up --exit-code-from ${{ matrix.case.exit-from }}
+          docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} pull
+          docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
           test_exit_code=$?
           galaxy_exit_code=$(docker inspect --format='{{.State.ExitCode}}' compose-v2_galaxy-server_1)
-          docker-compose ${{ matrix.case.files }} down
+          docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
           [ $galaxy_exit_code -eq 1 ] && exit 1 || exit $test_exit_code
         working-directory: ./compose-v2
         continue-on-error: false
@@ -84,7 +95,7 @@ jobs:
         uses: actions/upload-artifact@v1
         if: failure()
         with:
-          name: ${{ matrix.case.name }}_first-run
+          name: ${{ matrix.infrastructure.name }}_${{ matrix.test.name }}_first-run
           path: ./compose-v2/export/galaxy/database
       - name: Clean up after first run
         run: |
@@ -93,7 +104,7 @@ jobs:
         working-directory: ./compose-v2
       - name: Run tests a second time
         run: |
-          docker-compose ${{ matrix.case.files }} up --exit-code-from ${{ matrix.case.exit-from }}
+          docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
           test_exit_code=$?
           galaxy_exit_code=$(docker inspect --format='{{.State.ExitCode}}' compose-v2_galaxy-server_1)
           [ $galaxy_exit_code -eq 1 ] && exit 1 || exit $test_exit_code
@@ -107,5 +118,5 @@ jobs:
         uses: actions/upload-artifact@v1
         if: failure()
         with:
-          name: ${{ matrix.case.name }}_second-run
+          name: ${{ matrix.infrastructure.name }}_${{ matrix.test.name }}_first-run
           path: ./compose-v2/export/galaxy/database

--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -78,7 +78,7 @@ jobs:
         run: echo "::set-env name=IMAGE_TAG::latest"
       - name: Set WORKFLOWS env for worfklows-test
         if: matrix.test.workflow
-        run: echo "::set-env name=WORKFLOWS::${{ matrix.workflows }}"
+        run: echo "::set-env name=WORKFLOWS::${{ matrix.test.workflow }}"
       - name: Run tests for the first time
         run: |
           docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} pull

--- a/compose-v2/docker-compose.test.workflows.yml
+++ b/compose-v2/docker-compose.test.workflows.yml
@@ -4,6 +4,6 @@ services:
     image: ${IMAGE_DOMAIN:-andreassko}/galaxy-workflow-test:${IMAGE_TAG:-latest}
     build: galaxy-workflow-test
     environment:
-      - WORKFLOWS=training/variant-analysis/mapping-by-sequencing/mapping_by_sequencing.ga,sklearn/ard/ard.ga,GraphClust2/GC-lite.ga
+      - WORKFLOWS=${WORKFLOWS:-training/variant-analysis/mapping-by-sequencing/mapping_by_sequencing.ga,sklearn/ard/ard.ga,GraphClust2/GC-lite.ga}
     networks:
       - galaxy


### PR DESCRIPTION
To speed up the integration tests, we can run each test per workflow in parallel.
Also split up matrix to separate between infrastructure and the actual tests.