### PR TITLE
Use Selenium for integration test

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -12,6 +12,7 @@ jobs:
           - galaxy-configurator
           - galaxy-bioblend-test
           - galaxy-workflow-test
+          - galaxy-selenium-test
       fail-fast: false
     steps:
       - name: Checkout
@@ -67,6 +68,9 @@ jobs:
             files: -f docker-compose.test.yml -f docker-compose.test.workflows.yml
             exit-from: galaxy-workflow-test
             workflow: GraphClust2/GC-lite.ga
+          - name: selenium
+            files: -f docker-compose.test.yml -f docker-compose.test.selenium.yml
+            exit-from: galaxy-selenium-test
       fail-fast: false
     steps:
       - name: Checkout

--- a/compose-v2/docker-compose.test.selenium.yml
+++ b/compose-v2/docker-compose.test.selenium.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  galaxy-selenium-test:
+    image: ${IMAGE_DOMAIN:-andreassko}/galaxy-selenium-test:${IMAGE_TAG:-latest}
+    build: galaxy-selenium-test
+    environment:
+      - TESTS=${TESTS:-navigates_galaxy.py}
+    networks:
+      - galaxy

--- a/compose-v2/docker-compose.test.selenium.yml
+++ b/compose-v2/docker-compose.test.selenium.yml
@@ -4,6 +4,8 @@ services:
     image: ${IMAGE_DOMAIN:-andreassko}/galaxy-selenium-test:${IMAGE_TAG:-latest}
     build: galaxy-selenium-test
     environment:
-      - TESTS=${TESTS:-navigates_galaxy.py}
+      - TESTS=${TESTS:-navigates_galaxy.py,login.py}
+    volumes:
+      - ${EXPORT_DIR:-./export}/galaxy/database:/galaxy/database
     networks:
       - galaxy

--- a/compose-v2/galaxy-selenium-test/Dockerfile
+++ b/compose-v2/galaxy-selenium-test/Dockerfile
@@ -1,0 +1,20 @@
+FROM selenium/standalone-chrome:3.141.59
+
+ARG GALAXY_RELEASE=dev
+ARG GALAXY_REPO=https://github.com/galaxyproject/galaxy
+
+ENV GALAXY_ROOT=/galaxy
+
+USER root
+
+RUN apt update && apt install --no-install-recommends python-dev python-pip -y && rm -rf /var/lib/apt/lists/*
+RUN mkdir "${GALAXY_ROOT}" && chown seluser "${GALAXY_ROOT}"
+
+USER seluser
+RUN curl -L -s $GALAXY_REPO/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT \
+    && cd "${GALAXY_ROOT}" \
+    && ./scripts/common_startup.sh --skip-client-build --dev-wheels
+
+COPY run.sh /usr/bin/run.sh
+
+CMD "/usr/bin/run.sh"

--- a/compose-v2/galaxy-selenium-test/Dockerfile
+++ b/compose-v2/galaxy-selenium-test/Dockerfile
@@ -6,9 +6,9 @@ ARG GALAXY_REPO=https://github.com/galaxyproject/galaxy
 ENV GALAXY_ROOT=/galaxy
 
 USER root
-
-RUN apt update && apt install --no-install-recommends python-dev python-pip -y && rm -rf /var/lib/apt/lists/*
-RUN mkdir "${GALAXY_ROOT}" && chown seluser "${GALAXY_ROOT}"
+RUN apt update && apt install --no-install-recommends python-dev python-pip -y && rm -rf /var/lib/apt/lists/* \
+    && mkdir "${GALAXY_ROOT}" \
+    && chown seluser "${GALAXY_ROOT}"
 
 USER seluser
 RUN curl -L -s $GALAXY_REPO/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT \

--- a/compose-v2/galaxy-selenium-test/run.sh
+++ b/compose-v2/galaxy-selenium-test/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e # Stop script, if a test fails
+
+supervisord &
+
+sleep 5
+
+echo "Waiting for Galaxy..."
+until [ "$(curl -s -o /dev/null -w '%{http_code}' ${GALAXY_URL:-nginx})" -eq "200" ] && echo Galaxy started; do
+    sleep 1;
+done;
+
+export GALAXY_TEST_SELENIUM_REMOTE=1
+export GALAXY_TEST_SELENIUM_REMOTE_HOST=localhost
+export GALAXY_TEST_SELENIUM_REMOTE_PORT=4444
+export GALAXY_TEST_EXTERNAL_FROM_SELENIUM=http://${GALAXY_URL:-nginx}
+export GALAXY_TEST_EXTERNAL=http://${GALAXY_URL:-nginx}
+export GALAXY_CONFIG_MASTER_API_KEY=${GALAXY_DEFAULT_ADMIN_KEY:-admin}
+
+
+for test in $(echo $TESTS | sed "s/,/ /g"); do
+  echo "Running test $test"
+  ./galaxy/run_tests.sh --skip-common-startup -selenium "/galaxy/lib/galaxy_test/selenium/test_$test"
+done

--- a/compose-v2/galaxy-selenium-test/run.sh
+++ b/compose-v2/galaxy-selenium-test/run.sh
@@ -18,7 +18,7 @@ export GALAXY_TEST_EXTERNAL=http://${GALAXY_URL:-nginx}
 export GALAXY_CONFIG_MASTER_API_KEY=${GALAXY_DEFAULT_ADMIN_KEY:-admin}
 
 
-for test in $(echo $TESTS | sed "s/,/ /g"); do
+for test in $(echo "$TESTS" | sed "s/,/ /g"); do
   echo "Running test $test"
   ./galaxy/run_tests.sh --skip-common-startup -selenium "/galaxy/lib/galaxy_test/selenium/test_$test"
 done


### PR DESCRIPTION
This adds a galaxy-selenium-test container and compose-file to run integration tests using the Galaxy Selenium tests. Right now, only `navigates_galaxy` and `login` are tested, but we can extend the tests in the future (after we found out why other tests fail).