### PR TITLE
CI: Find errors in non-galaxy containers

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -101,9 +101,9 @@ jobs:
             set +e
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
-            galaxy_exit_code=$(docker inspect --format='{{.State.ExitCode}}' compose-v2_galaxy-server_1)
+            error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
-            if [ $galaxy_exit_code -eq 1 ] || [ $test_exit_code -eq 1 ] ; then
+            if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
               echo "Test failed..";
               continue;
             else
@@ -139,8 +139,8 @@ jobs:
             set +e
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
-            galaxy_exit_code=$(docker inspect --format='{{.State.ExitCode}}' compose-v2_galaxy-server_1)
-            if [ $galaxy_exit_code -eq 1 ] || [ $test_exit_code -eq 1 ] ; then
+            error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
+            if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
               echo "Test failed..";
               continue;
             else

--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -159,5 +159,5 @@ jobs:
         uses: actions/upload-artifact@v1
         if: failure() && matrix.test.second_run == 'true'
         with:
-          name: ${{ matrix.infrastructure.name }}_${{ matrix.test.name }}_first-run
+          name: ${{ matrix.infrastructure.name }}_${{ matrix.test.name }}_second-run
           path: ./compose-v2/export/galaxy/database


### PR DESCRIPTION
To not only find errors in the Galaxy container or the tests, we want to consider the exit codes of all containers. With this change, the number of exit-code==1 is counted (which should be 0 in normal cases) to determine if the run has been successful. Before that, Nginx might have failed and stopped the setup, which the pipeline considered successful. 

Also: Named artifacts of second run correctly. This might have resulted in overwriting existing ones  earlier.