### PR TITLE
Fix GALAXY_PROXY_PREFIX

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -55,7 +55,7 @@ jobs:
             files: -f docker-compose.yml
           - name: galaxy-proxy-prefix
             files: -f docker-compose.yml
-            env: GALAXY_PROXY_PREFIX=/galaxy GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=http://localhost/galaxy
+            env: GALAXY_PROXY_PREFIX=/arbitrary_Galaxy-prefix GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=http://localhost/arbitrary_Galaxy-prefix
           - name: galaxy-htcondor
             files: -f docker-compose.yml -f docker-compose.htcondor.yml
         test:

--- a/compose-v2/galaxy-configurator/templates/galaxy/galaxy.yml.j2
+++ b/compose-v2/galaxy-configurator/templates/galaxy/galaxy.yml.j2
@@ -2,7 +2,7 @@ uwsgi:
 {{ galaxy_uwsgi | to_nice_yaml(indent=2) | indent(2, first=True) }}
 
   {% if GALAXY_PROXY_PREFIX %}
-  mount: /galaxy=galaxy.webapps.galaxy.buildapp:uwsgi_app()
+  mount: /{{ GALAXY_PROXY_PREFIX | regex_replace("^/", "") | regex_replace("/$", "") }}=galaxy.webapps.galaxy.buildapp:uwsgi_app()
   manage-script-name: true
   {% else %}
   module: galaxy.webapps.galaxy.buildapp:uwsgi_app()


### PR DESCRIPTION
Earlier the prefix was set fixed to `/galaxy`, which was also the one tested of course. This fixes it and adds a better test for the prefix, to prevent/detect similar issues in the future.