### PR TITLE
Python3 for test containers

### DIFF
--- a/compose-v2/galaxy-bioblend-test/Dockerfile
+++ b/compose-v2/galaxy-bioblend-test/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.11 as build
 ENV BIOBLEND_VERSION=0.13.0
 
 ADD "https://github.com/galaxyproject/bioblend/archive/v$BIOBLEND_VERSION.zip" /src/bioblend.zip
-RUN apk update && apk add unzip python2-dev python3-dev curl \
+RUN apk update && apk add unzip python3-dev curl \
     && pip3 install tox pep8 \
     && cd /src \
     && unzip bioblend.zip && rm bioblend.zip \

--- a/compose-v2/galaxy-workflow-test/Dockerfile
+++ b/compose-v2/galaxy-workflow-test/Dockerfile
@@ -3,9 +3,9 @@ FROM alpine:3.11
 ENV TEST_REPO=${TEST_REPO:-https://github.com/usegalaxy-eu/workflow-testing} \
     TEST_RELEASE=${TEST_RELEASE:-master}
 
-RUN apk add --no-cache bash python py-setuptools curl \
-    && apk add --no-cache --virtual build-dep gcc libxml2-dev libxslt-dev musl-dev linux-headers python-dev py-pip \
-    && pip install planemo \
+RUN apk add --no-cache bash python3 curl \
+    && apk add --no-cache --virtual build-dep gcc libxml2-dev libxslt-dev musl-dev linux-headers python3-dev \
+    && pip3 install planemo \
     && mkdir /src && cd /src \
     && curl -L -s $TEST_REPO/archive/$TEST_RELEASE.tar.gz | tar xzf - --strip-components=1 \
     && apk del build-dep


### PR DESCRIPTION
This removes Python2 dependencies for the Workflow tests and Bioblend tests.