### PR TITLE
Add Slurm setup for Galaxy

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -10,6 +10,8 @@ jobs:
           - galaxy-nginx
           - galaxy-postgres
           - galaxy-htcondor
+          - galaxy-slurm
+          - galaxy-slurm-node-discovery
           - galaxy-configurator
           - galaxy-bioblend-test
           - galaxy-workflow-test
@@ -58,6 +60,8 @@ jobs:
             env: GALAXY_PROXY_PREFIX=/arbitrary_Galaxy-prefix GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=http://localhost/arbitrary_Galaxy-prefix
           - name: galaxy-htcondor
             files: -f docker-compose.yml -f docker-compose.htcondor.yml
+          - name: galaxy-slurm
+            files: -f docker-compose.yml -f docker-compose.slurm.yml
         test:
           - name: bioblend
             files: -f docker-compose.test.yml -f docker-compose.test.bioblend.yml

--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -62,6 +62,8 @@ jobs:
             files: -f docker-compose.yml -f docker-compose.htcondor.yml
           - name: galaxy-slurm
             files: -f docker-compose.yml -f docker-compose.slurm.yml
+            env: SLURM_NODE_COUNT=3
+            options: --scale slurm_node=3
         test:
           - name: bioblend
             files: -f docker-compose.test.yml -f docker-compose.test.bioblend.yml
@@ -104,7 +106,7 @@ jobs:
             echo "Running test - try \#$i"
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} pull
             set +e
-            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
             error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
@@ -142,7 +144,7 @@ jobs:
           for i in 1 2; do
             echo "Running test - try \#$i"
             set +e
-            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
             error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
             if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
@@ -203,7 +205,7 @@ jobs:
             echo "Running test - try \#$i"
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} pull
             set +e
-            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
             error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
@@ -241,7 +243,7 @@ jobs:
           for i in 1 2; do
             echo "Running test - try \#$i"
             set +e
-            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up --exit-code-from ${{ matrix.test.exit-from }}
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
             error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
             if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then

--- a/compose-v2/base_config.yml
+++ b/compose-v2/base_config.yml
@@ -20,3 +20,41 @@ galaxy_uwsgi:
 galaxy:
   tool_dependency_dir: /tool_deps
   tool_data_table_config_path: /cvmfs/data.galaxyproject.org/byhand/location/tool_data_table_conf.xml,/cvmfs/data.galaxyproject.org/managed/location/tool_data_table_conf.xml
+
+# Probably needs more polishing, but at least it works..
+slurm:
+  ControlMachine: "slurmctld"
+  AuthType: "auth/munge"
+  CacheGroups: "0"
+  CryptoType: "crypto/munge"
+  MpiDefault: "none"
+  ProctrackType: "proctrack/pgid"
+  ReturnToService: "1"
+  SlurmctldPidFile: "/var/run/slurmctld.pid"
+  SlurmctldPort: "6817"
+  SlurmdPidFile: "/var/run/slurmd.pid"
+  SlurmdPort: "6818"
+  SlurmdSpoolDir: "/tmp/slurmd"
+  SlurmUser: "slurm"
+  StateSaveLocation: "/tmp/slurm"
+  SwitchType: "switch/none"
+  TaskPlugin: "task/none"
+  InactiveLimit: "0"
+  KillWait: "30"
+  MinJobAge: "300"
+  SlurmctldTimeout: "120"
+  SlurmdTimeout: "300"
+  Waittime: "0"
+  FastSchedule: "1"
+  SchedulerType: "sched/backfill"
+  SchedulerPort: "7321"
+  SelectType: "select/cons_res"
+  SelectTypeParameters: "CR_Core_Memory"
+  AccountingStorageType: "accounting_storage/none"
+  AccountingStoreJobComment: "YES"
+  ClusterName: "Cluster"
+  JobCompType: "jobcomp/none"
+  JobAcctGatherFrequency: "30"
+  JobAcctGatherType: "jobacct_gather/none"
+  SlurmctldDebug: info
+  SlurmdDebug: info

--- a/compose-v2/docker-compose.slurm.yml
+++ b/compose-v2/docker-compose.slurm.yml
@@ -1,0 +1,46 @@
+version: "3"
+services:
+  galaxy-configurator:
+    environment:
+      - GALAXY_JOB_DESTINATION=slurm
+      - SLURM_OVERWRITE_CONFIG=true
+      - SLURM_NODE_COUNT=${SLURM_NODE_COUNT:-1}
+      - SLURM_NODE_HOSTNAME=compose-v2_slurm_node
+    volumes:
+      - ${EXPORT_DIR:-./export}/slurm_config:/etc/slurm-llnl
+  galaxy-server:
+    volumes:
+      - ${EXPORT_DIR:-./export}/munge:/etc/munge
+      - ${EXPORT_DIR:-./export}/slurm_config:/etc/slurm-llnl
+  slurmctld:
+    image: ${IMAGE_DOMAIN:-andreassko}/galaxy-slurm:${IMAGE_TAG:-latest}
+    build: galaxy-slurm
+    command: ["slurmctld"]
+    hostname: slurmctld
+    volumes:
+      - ${EXPORT_DIR:-./export}/slurm_config:/etc/slurm-llnl
+      - ${EXPORT_DIR:-./export}/munge:/etc/munge
+    networks:
+      - galaxy
+  slurm_node_discovery:
+    image: ${IMAGE_DOMAIN:-andreassko}/galaxy-slurm-node-discovery:${IMAGE_TAG:-latest}
+    build: galaxy-slurm-node-discovery
+    volumes:
+      - ${EXPORT_DIR:-./export}/slurm_config:/etc/slurm-llnl
+      - /var/run/docker.sock:/var/run/docker.sock
+  slurm_node:
+    image: ${IMAGE_DOMAIN:-andreassko}/galaxy-slurm:${IMAGE_TAG:-latest}
+    build: galaxy-slurm
+    command: ["slurmd"]
+    labels:
+      slurm_node: true
+    volumes:
+      - ${EXPORT_DIR:-./export}/galaxy/database:/galaxy/database
+      - ${EXPORT_DIR:-./export}/galaxy/tools:/galaxy/tools:ro
+      - ${EXPORT_DIR:-./export}/galaxy/lib:/galaxy/lib:ro
+      - ${EXPORT_DIR:-./export}/galaxy/.venv:/galaxy/.venv
+      - ${EXPORT_DIR:-./export}/tool_deps:/tool_deps
+      - ${EXPORT_DIR:-./export}/slurm_config:/etc/slurm-llnl
+      - ${EXPORT_DIR:-./export}/munge:/etc/munge
+    networks:
+      - galaxy

--- a/compose-v2/galaxy-configurator/customize.py
+++ b/compose-v2/galaxy-configurator/customize.py
@@ -25,7 +25,8 @@ def alter_context(context):
       "GALAXY_CONFIG_": "galaxy",
       "GALAXY_UWSGI_CONFIG_": "galaxy_uwsgi",
       "GALAXY_JOB_METRICS_": "galaxy_job_metrics",
-      "NGINX_CONFIG_": "nginx"
+      "NGINX_CONFIG_": "nginx",
+      "SLURM_CONFIG_": "slurm"
     }
 
     # Add values from possible input file if existent
@@ -48,7 +49,12 @@ def alter_context(context):
     for key, value in os.environ.items():
       for frm, to in translations.items():
         if key.startswith(frm):
-          key = key[len(frm):].lower()
+          # Format key depending on it being uppercase or not
+          # (to cope with different formatings: compare Slurm with Galaxy)
+          key = key[len(frm):]
+          if key.isupper():
+            key = key.lower()
+
           if key not in new_context[to]:
             new_context[to][key] = value
 

--- a/compose-v2/galaxy-configurator/templates/galaxy/job_conf.xml.j2
+++ b/compose-v2/galaxy-configurator/templates/galaxy/job_conf.xml.j2
@@ -4,12 +4,18 @@
     <plugins>
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
         <plugin id="condor" type="runner" load="galaxy.jobs.runners.condor:CondorJobRunner"/>
+        <plugin id="slurm" type="runner" load="galaxy.jobs.runners.slurm:SlurmJobRunner">
+            <param id="drmaa_library_path">/usr/lib/slurm-drmaa/lib/libdrmaa.so</param>
+        </plugin>
     </plugins>
     <destinations default="{{ GALAXY_JOB_DESTINATION|default('local') }}">
         <destination id="local" runner="local">
             <env file="/galaxy/.venv/bin/activate" />
         </destination>
         <destination id="condor" runner="condor">
+            <env file="/galaxy/.venv/bin/activate" />
+        </destination>
+        <destination id="slurm" runner="slurm">
             <env file="/galaxy/.venv/bin/activate" />
         </destination>
         {% if GALAXY_SINGULARTIY %}

--- a/compose-v2/galaxy-configurator/templates/slurm/slurm.conf.j2
+++ b/compose-v2/galaxy-configurator/templates/slurm/slurm.conf.j2
@@ -1,0 +1,9 @@
+{% for key, value in slurm.items() -%}
+{{ key }}={{ value }}
+{% endfor %}
+
+{% set slurm_node_count = SLURM_NODE_COUNT | int -%}
+{% for i in range(1, slurm_node_count + 1) -%}
+NodeName={{ SLURM_NODE_HOSTNAME }}_{{ i }} NodeAddr={{ SLURM_NODE_HOSTNAME }}_{{ i }} NodeHostname={{ SLURM_NODE_HOSTNAME }}_{{ i }} CPUs={{ slurm.node_cpus | default(1, true) }} RealMemory={{ slurm.node_memory | default(1024, true) }} State=UNKNOWN
+{% endfor %}
+PartitionName=work Nodes={% for i in range(1, slurm_node_count + 1) -%}{{ SLURM_NODE_HOSTNAME }}_{{ i }}{%- if not loop.last -%},{% endif %}{% endfor %} Default=YES MaxTime=INFINITE State=UP Shared=YES # TODO

--- a/compose-v2/galaxy-server/Dockerfile
+++ b/compose-v2/galaxy-server/Dockerfile
@@ -88,7 +88,10 @@ FROM ubuntu:18.04 as final
 COPY ./files/common_cleanup.sh /usr/bin/common_cleanup.sh
 
 # Install remaining dependencies
-RUN apt update && apt install --no-install-recommends ca-certificates gnupg2 netcat libpq-dev mercurial make libgomp1  -y \
+RUN apt update && apt install --no-install-recommends ca-certificates gcc gnupg2 libgomp1 liblzma-dev libbz2-dev libpq-dev \
+                                                      mercurial make netcat python-dev python-setuptools python-pip zlib1g-dev -y \
+    && pip install Cython wheel \
+    && pip install pysam \
     && /usr/bin/common_cleanup.sh
 
 # Install HTCondor

--- a/compose-v2/galaxy-server/Dockerfile
+++ b/compose-v2/galaxy-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:19.10 as build_base
+FROM buildpack-deps:18.04 as build_base
 
 ARG GALAXY_RELEASE=release_19.09
 ARG GALAXY_REPO=https://github.com/galaxyproject/galaxy
@@ -57,7 +57,7 @@ RUN apt update && apt install --no-install-recommends python-dev python-pip -y &
     && . $GALAXY_ROOT/.venv/bin/activate && pip install psycopg2 \
     # Fix as cheetah was missing C library first
     && pip uninstall cheetah -y \
-    && pip install cheetah \
+    && pip install cheetah drmaa \
     && deactivate \
     && rm -rf .ci .circleci .coveragerc .gitignore .travis.yml CITATION CODE_OF_CONDUCT.md CONTRIBUTING.md CONTRIBUTORS.md \
               LICENSE.txt Makefile README.rst SECURITY_POLICY.md pytest.ini tox.ini \
@@ -69,7 +69,7 @@ FROM build_base as build_singularity
 COPY ./files/common_cleanup.sh /usr/bin/common_cleanup.sh
 # Install Go (only needed for building singularity)
 ENV GO_VERSION=1.13
-RUN apt update && apt install --no-install-recommends cryptsetup-bin -y \
+RUN apt update && apt install --no-install-recommends cryptsetup-bin uuid-dev -y \
     && wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
     && tar -C /usr/local -xzvf go${GO_VERSION}.linux-amd64.tar.gz \
     && rm go${GO_VERSION}.linux-amd64.tar.gz \
@@ -84,14 +84,33 @@ RUN wget https://github.com/sylabs/singularity/releases/download/v${SINGULARITY_
     && make -C builddir \
     && /usr/bin/common_cleanup.sh
 
-FROM ubuntu:19.10 as final
+FROM ubuntu:18.04 as final
 COPY ./files/common_cleanup.sh /usr/bin/common_cleanup.sh
+
+# Install remaining dependencies
+RUN apt update && apt install --no-install-recommends ca-certificates gnupg2 netcat libpq-dev mercurial make libgomp1  -y \
+    && /usr/bin/common_cleanup.sh
 
 # Install HTCondor
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt install --no-install-recommends htcondor -y \
     && rm /etc/condor/condor_config.local \
     && find / -name '*.pyc' -delete | true \
+    && /usr/bin/common_cleanup.sh
+
+# Install Slurm client
+ENV MUNGER_USER=munge \
+    MUNGE_UID=1200 \
+    MUNGE_GID=1200
+RUN groupadd -r $MUNGER_USER -g $MUNGE_GID \
+    && useradd -u $MUNGE_UID -r -g $MUNGER_USER $MUNGER_USER \
+    && echo "deb http://ppa.launchpad.net/natefoo/slurm-drmaa/ubuntu bionic main" >> /etc/apt/sources.list \
+    && echo "deb-src http://ppa.launchpad.net/natefoo/slurm-drmaa/ubuntu bionic main" >> /etc/apt/sources.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8DE68488997C5C6BA19021136F2CC56412788738 \
+    && apt update \
+    && apt install --no-install-recommends slurm-client slurmd slurmctld slurm-drmaa1 -y \
+    && apt --no-install-recommends install munge libmunge-dev -y \
+    && ln -s /usr/lib/slurm-drmaa/lib/libdrmaa.so.1 /usr/lib/slurm-drmaa/lib/libdrmaa.so \
     && /usr/bin/common_cleanup.sh
 
 # Install CVMFS
@@ -106,10 +125,6 @@ RUN apt update \
     && /usr/bin/common_cleanup.sh
 
 COPY files/cvmfs /etc/cvmfs
-
-# Install remaining dependencies
-RUN apt update && apt install --no-install-recommends ca-certificates netcat libpq-dev mercurial libgomp1  -y \
-    && /usr/bin/common_cleanup.sh
 
 ENV EXPORT_DIR=/export \
     GALAXY_ROOT=/galaxy \
@@ -145,7 +160,7 @@ COPY --chown=$GALAXY_USER:$GALAXY_USER --from=build_miniconda /etc/profile.d/con
 
 # Install Singularity
 COPY --from=build_singularity /singularity /singularity
-RUN apt update && apt install make squashfs-tools -y \
+RUN apt update && apt install squashfs-tools -y \
     && make -C /singularity/builddir install \
     && rm -rf /singularity \
     && sed -e '/bind path = \/etc\/localtime/s/^/#/g' -i /usr/local/etc/singularity/singularity.conf \

--- a/compose-v2/galaxy-server/files/start.sh
+++ b/compose-v2/galaxy-server/files/start.sh
@@ -93,6 +93,12 @@ if [ -f "/etc/condor/condor_config.local" ]; then
     # "$HTCONDOR_ROOT/sbin/condor_master"
 fi
 
+if [ -f /etc/munge/munge.key ]; then
+    echo "Munge key found"
+    echo "Starting Munge.."
+    /etc/init.d/munge start
+fi
+
 # In case the user wants the default admin to be created, do so.
 if [[ -n $GALAXY_DEFAULT_ADMIN_USER ]]; then
     echo "Creating admin user $GALAXY_DEFAULT_ADMIN_USER with key $GALAXY_DEFAULT_ADMIN_KEY and password $GALAXY_DEFAULT_ADMIN_PASSWORD if not existing"

--- a/compose-v2/galaxy-slurm-node-discovery/Dockerfile
+++ b/compose-v2/galaxy-slurm-node-discovery/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.11
+
+RUN apk add curl jq
+
+COPY run.sh /usr/bin/run.sh
+
+ENTRYPOINT /usr/bin/run.sh

--- a/compose-v2/galaxy-slurm-node-discovery/run.sh
+++ b/compose-v2/galaxy-slurm-node-discovery/run.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This script is used to replace the container name of a slurm node
+# with its correct hostname. This is needed, as a hostname can not
+# include '_', which is the case for docker-compose.
+sleep 5
+echo "Waiting for Galaxy configurator to finish and release lock"
+until [ ! -f /etc/slurm-llnl/configurator.lock ] && echo Lock released; do
+    sleep 0.1;
+done;
+
+grep < /etc/slurm-llnl/slurm.conf "NodeName=" | while read -r line; do
+  node=$(echo "$line" | sed "s/NodeName=\(.*\) \(NodeAddr.*\)/\1/")
+  node_hostname=$(curl -s --unix-socket /var/run/docker.sock -XGET \
+                       -H "Content-Type: application/json" http://v1.40/containers/json \
+                       -G --data-urlencode "filters={\"name\":[\"$node\"]}" \
+                  | jq -r '.[0] | .["Id"]' | head -c 12)
+  sed -i "s/$node/$node_hostname/g" /etc/slurm-llnl/slurm.conf
+done
+
+sleep infinity

--- a/compose-v2/galaxy-slurm/Dockerfile
+++ b/compose-v2/galaxy-slurm/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:20.04 as final
+
+ENV SLURM_USER=galaxy \
+    SLURM_UID=1450 \
+    SLURM_GID=1450 \
+    MUNGER_USER=munge \
+    MUNGE_UID=1200 \
+    MUNGE_GID=1200
+
+RUN groupadd -r $SLURM_USER -g $SLURM_GID \
+    && useradd -u $SLURM_UID -r -g $SLURM_USER $SLURM_USER \
+    && groupadd -r $MUNGER_USER -g $MUNGE_GID \
+    && useradd -u $MUNGE_UID -r -g $MUNGER_USER $MUNGER_USER \
+    && apt update \
+    && apt install --no-install-recommends gosu munge python2 python2-dev slurm-wlm -y \
+    && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/*
+
+COPY start.sh /usr/bin/start.sh
+
+ENTRYPOINT [ "/usr/bin/start.sh" ]

--- a/compose-v2/galaxy-slurm/start.sh
+++ b/compose-v2/galaxy-slurm/start.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Inspired by: https://github.com/giovtorres/slurm-docker-cluster
+
+sleep 10 # ToDo: Use locking or so to be sure we really have the newest version
+echo "Waiting for Slurm config"
+until [ -f /etc/slurm-llnl/slurm.conf ] && echo Config found; do
+    sleep 0.5;
+done;
+
+if [ "$1" = "slurmctld" ]; then
+    if [ ! -f /etc/munge/munge.key ]; then
+      gosu "$MUNGE_USER" /usr/sbin/create-munge-key
+    fi
+    echo "Starting Munge.."
+    /etc/init.d/munge start
+
+    echo "Starting Slurmctld"
+    exec /usr/sbin/slurmctld -D
+fi
+
+if [ "$1" = "slurmd" ]; then
+    echo "Waiting for munge.key"
+    until [ -f /etc/munge/munge.key ] && echo munge.key found; do
+        sleep 0.5;
+    done;
+    sleep 1
+
+    echo "Starting Munge.."
+    /etc/init.d/munge start
+
+    "Starting Slurmd"
+    exec /usr/sbin/slurmd -D
+fi
+
+exec "$@"


### PR DESCRIPTION
Adds a docker-compose setup to use a local Slurm cluster: `docker-compose.slurm.yml`. 
Added two new containers: `galaxy-slurm` (used for slurm controller and cluster) and `galaxy-slurm-node-discovery` (dynamically rewrites slurm.conf to the correct hostnames).
Slurm is configured via Galaxy-Configurator and settings can be changed with the `base_conf.yml` or via env variables in the format of `SLURM_CONFIG_*`.