### PR TITLE
Timeout within docker-compose tests

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -71,23 +71,28 @@ jobs:
           - name: bioblend
             files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.bioblend.yml
             exit-from: galaxy-bioblend-test
+            timeout: 30
             second_run: "true"
           - name: workflow_ard
             files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.workflows.yml
             exit-from: galaxy-workflow-test
             workflow: sklearn/ard/ard.ga
+            timeout: 30
             second_run: "true"
           - name: workflow_mapping_by_sequencing
             files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.workflows.yml
             exit-from: galaxy-workflow-test
             workflow: training/variant-analysis/mapping-by-sequencing/mapping_by_sequencing.ga
+            timeout: 30
           - name: workflow_GC-lite
             files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.workflows.yml
             exit-from: galaxy-workflow-test
             workflow: GraphClust2/GC-lite.ga
+            timeout: 30
           - name: selenium
             files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.selenium.yml
             exit-from: galaxy-selenium-test
+            timeout: 30
       fail-fast: false
     steps:
       - name: Checkout
@@ -103,6 +108,7 @@ jobs:
       - name: Run tests for the first time
         run: |
           export ${{ matrix.infrastructure.env }}
+          export TIMEOUT=${{ matrix.test.timeout }}
           docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} config
           env
           for i in 1 2; do
@@ -124,7 +130,6 @@ jobs:
         shell: bash
         working-directory: ./compose-v2
         continue-on-error: false
-        timeout-minutes: 120
       - name: Allow upload-artifact read access
         if: failure()
         run: sudo chmod -R +r ./compose-v2/export/galaxy/database
@@ -144,6 +149,7 @@ jobs:
         if: matrix.test.second_run == 'true'
         run: |
           export ${{ matrix.infrastructure.env }}
+          export TIMEOUT=${{ matrix.test.timeout }}
           for i in 1 2; do
             echo "Running test - try \#$i"
             set +e

--- a/compose-v2/tests/docker-compose.test.yml
+++ b/compose-v2/tests/docker-compose.test.yml
@@ -10,3 +10,11 @@ services:
     environment:
       - GALAXY_CONFIG_CLEANUP_JOB=never
       - DONT_EXIT=true
+  # Terminates the container after $TIMEOUT minutes
+  # which results in the whole setup terminating if --exit-code-from
+  # is set (see CI)
+  timeout:
+    image: alpine:3.11
+    environment:
+      - TIMEOUT=${TIMEOUT:-120}
+    command: sh -c "echo \"Setting timeout to $$TIMEOUT minutes\" && sleep $$((( $$TIMEOUT * 60 ))) && echo \"Timeout after $$TIMEOUT minutes!\" && exit 1"


### PR DESCRIPTION
A simple alpine container is used for creating a timeout after which the setup is terminated (if `--exit-code-from` is set).
Github Actions also offer a timeout, however using a built-in timeout makes it possible to do a retry run, which may be handy with flaky tests. The default timeout is 120 minutes, but can be tweaked using the `TIMEOUT` environment variable.