### PR TITLE
Export Planemo test output

### DIFF
--- a/compose-v2/tests/docker-compose.test.workflows.yml
+++ b/compose-v2/tests/docker-compose.test.workflows.yml
@@ -6,5 +6,7 @@ services:
     environment:
       - GALAXY_URL=http://nginx${GALAXY_PROXY_PREFIX:-}/
       - WORKFLOWS=${WORKFLOWS:-training/variant-analysis/mapping-by-sequencing/mapping_by_sequencing.ga,sklearn/ard/ard.ga,GraphClust2/GC-lite.ga}
+    volumes:
+      - ${EXPORT_DIR:-./../export}/galaxy/database:/galaxy/database
     networks:
       - galaxy

--- a/compose-v2/tests/galaxy-workflow-test/run.sh
+++ b/compose-v2/tests/galaxy-workflow-test/run.sh
@@ -10,9 +10,11 @@ for workflow in $(echo $WORKFLOWS | sed "s/,/ /g")
 do
     echo "Running test $workflow"
     planemo $PLANEMO_OPTIONS test \
-	--galaxy_url "${GALAXY_URL:-nginx}" \
-	--galaxy_admin_key "${GALAXY_USER_KEY:-fakekey}" \
-	--shed_install \
-	--engine external_galaxy \
-	"$workflow";
+      --galaxy_url "${GALAXY_URL:-nginx}" \
+      --galaxy_admin_key "${GALAXY_USER_KEY:-fakekey}" \
+      --shed_install \
+      --engine external_galaxy \
+      --test_output ${GALAXY_ROOT:-/galaxy}/database/tool_test_output.html \
+      --test_output_json ${GALAXY_ROOT:-/galaxy}/database/tool_test_output.json \
+      "$workflow";
 done


### PR DESCRIPTION
If a workflow test fails, it is helpful to consider the test_output file of Planemo. With this change, the output is stored under /galaxy/database and is therefore also stored in the CI artifacts.