### PR TITLE
Let ENVs overwrite base_config.yml

### DIFF
--- a/compose-v2/galaxy-configurator/customize.py
+++ b/compose-v2/galaxy-configurator/customize.py
@@ -58,8 +58,7 @@ def alter_context(context):
                 if key.isupper():
                     key = key.lower()
 
-                if key not in new_context[to]:
-                    new_context[to][key] = value
+                new_context[to][key] = value
 
     context = new_context
 


### PR DESCRIPTION
It may be useful to overwrite existing configuration in `base_config.yml` on the fly using environment variables. So if, for example, `tool_dependency_dir` is configured in base_config.yml, it can be overwritten by `GALAXY_CONFIG_TOOL_DEPENDENCY_DIR=/different-path`.