### PR TITLE
Increase Nginx timeout for tests

### DIFF
--- a/compose-v2/galaxy-configurator/templates/nginx/nginx.conf.j2
+++ b/compose-v2/galaxy-configurator/templates/nginx/nginx.conf.j2
@@ -14,7 +14,7 @@ http {
   gzip_buffers 16 8k;
 
   # allow up to 3 minutes for Galaxy to respond to slow requests before timing out
-  uwsgi_read_timeout 180;
+  uwsgi_read_timeout {{ NGINX_UWSGI_READ_TIMEOUT | default(180, true) }};
 
   # maximum file upload size
   client_max_body_size 10g;

--- a/compose-v2/tests/docker-compose.test.yml
+++ b/compose-v2/tests/docker-compose.test.yml
@@ -9,6 +9,7 @@ services:
   galaxy-configurator:
     environment:
       - GALAXY_CONFIG_CLEANUP_JOB=never
+      - NGINX_UWSGI_READ_TIMEOUT=3600
       - DONT_EXIT=true
   # Terminates the container after $TIMEOUT minutes
   # which results in the whole setup terminating if --exit-code-from


### PR DESCRIPTION
Some workflow tests use older tools, which are not always available (at least it seems so). If a timeout happens, Planemo just continues to check for the not available tool to be installed, which results in the whole test to time out. This change increases the UWSGI read timeout of Nginx to 60 minutes to help with that.

* Introducing NGINX_UWSGI_READ_TIMEOUT
* Setting NGINX_UWSGI_READ_TIMEOUT to 3600s for
tests