### PR TITLE
Unifi admin credentials with tests

### DIFF
--- a/compose-v2/docker-compose.yml
+++ b/compose-v2/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - GALAXY_DEFAULT_ADMIN_USER=admin
       - GALAXY_DEFAULT_ADMIN_EMAIL=admin@galaxy.org
       - GALAXY_DEFAULT_ADMIN_PASSWORD=password
-      - GALAXY_DEFAULT_ADMIN_KEY=admin
+      - GALAXY_DEFAULT_ADMIN_KEY=fakekey
     hostname: galaxy-server
     privileged: True
     ports:

--- a/compose-v2/tests/docker-compose.test.yml
+++ b/compose-v2/tests/docker-compose.test.yml
@@ -1,11 +1,5 @@
 version: "3"
 services:
-  galaxy-server:
-    environment:
-      - GALAXY_DEFAULT_ADMIN_USER=admin
-      - GALAXY_DEFAULT_ADMIN_EMAIL=admin@galaxy.org
-      - GALAXY_DEFAULT_ADMIN_PASSWORD=password
-      - GALAXY_DEFAULT_ADMIN_KEY=fakekey
   galaxy-configurator:
     environment:
       - GALAXY_CONFIG_CLEANUP_JOB=never


### PR DESCRIPTION
The admin key for the regular setup was different compared to the test setup, which resulted in problems if the database was reused. With this change, the test setup uses the same credentials (it actually just reuses them).