### PR TITLE
Enable using Slurm with Singularity

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -83,6 +83,14 @@ jobs:
               - workflow_mapping_by_sequencing
               - workflow_GC-lite
               - selenium
+          - name: galaxy-slurm-singularity
+            files: -f docker-compose.yml -f docker-compose.slurm.yml -f docker-compose.singularity.yml
+            exclude_test:
+              - bioblend
+              - workflow_ard
+              - workflow_mapping_by_sequencing
+              - workflow_GC-lite
+              - selenium
         test:
           - name: bioblend
             files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.bioblend.yml

--- a/compose-v2/docker-compose.htcondor.yml
+++ b/compose-v2/docker-compose.htcondor.yml
@@ -6,26 +6,26 @@ services:
     hostname: htcondor-master
     volumes:
       - ./static_conf/htcondor_master.conf:/etc/condor/condor_config.local:ro
-    networks: 
+    networks:
       - galaxy
   htcondor-executor:
     image: ${IMAGE_DOMAIN:-andreassko}/galaxy-htcondor:${IMAGE_TAG:-latest}
     build: galaxy-htcondor
     hostname: htcondor-executor
-    environment: 
+    environment:
       - CONDOR_HOST=htcondor-master
-    volumes: 
+    volumes:
       - ${EXPORT_DIR:-./export}/galaxy/database:/galaxy/database
       - ${EXPORT_DIR:-./export}/galaxy/tools:/galaxy/tools:ro
       - ${EXPORT_DIR:-./export}/galaxy/lib:/galaxy/lib:ro
       - ${EXPORT_DIR:-./export}/galaxy/.venv:/galaxy/.venv
       - ${EXPORT_DIR:-./export}/tool_deps:/tool_deps
       - ./static_conf/htcondor_executor.conf:/etc/condor/condor_config.local:ro
-    networks: 
+    networks:
       - galaxy
   galaxy-server:
     volumes:
       - ./static_conf/htcondor_galaxy.conf:/etc/condor/condor_config.local:ro
   galaxy-configurator:
-    environment: 
-      - GALAXY_JOB_DESTINATION=condor
+    environment:
+      - GALAXY_JOB_RUNNER=condor

--- a/compose-v2/docker-compose.singularity.yml
+++ b/compose-v2/docker-compose.singularity.yml
@@ -4,5 +4,5 @@ services:
     environment:
       - HOST_PWD=$PWD
       - GALAXY_SINGULARTIY=true
-      - GALAXY_JOB_DESTINATION=singularity_local
+      - GALAXY_DEPENDENCY_RESOLUTION=singularity
       - GALAXY_CONFIG_CONDA_AUTO_INSTALL=false

--- a/compose-v2/docker-compose.slurm.yml
+++ b/compose-v2/docker-compose.slurm.yml
@@ -32,6 +32,7 @@ services:
     image: ${IMAGE_DOMAIN:-andreassko}/galaxy-slurm:${IMAGE_TAG:-latest}
     build: galaxy-slurm
     command: ["slurmd"]
+    privileged: true
     labels:
       slurm_node: true
     volumes:
@@ -42,5 +43,6 @@ services:
       - ${EXPORT_DIR:-./export}/tool_deps:/tool_deps
       - ${EXPORT_DIR:-./export}/slurm_config:/etc/slurm-llnl
       - ${EXPORT_DIR:-./export}/munge:/etc/munge
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - galaxy

--- a/compose-v2/docker-compose.slurm.yml
+++ b/compose-v2/docker-compose.slurm.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   galaxy-configurator:
     environment:
-      - GALAXY_JOB_DESTINATION=slurm
+      - GALAXY_JOB_RUNNER=slurm
       - SLURM_OVERWRITE_CONFIG=true
       - SLURM_NODE_COUNT=${SLURM_NODE_COUNT:-1}
       - SLURM_NODE_HOSTNAME=compose-v2_slurm_node

--- a/compose-v2/docker-compose.yml
+++ b/compose-v2/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     environment:
       - EXPORT_DIR=${EXPORT_DIR:-./export}
       - GALAXY_OVERWRITE_CONFIG=true
+      - GALAXY_DEPENDENCY_RESOLUTION=conda
+      - GALAXY_JOB_RUNNER=local
       - GALAXY_CONFIG_ADMIN_USERS=admin@galaxy.org
       - GALAXY_CONFIG_DATABASE_CONNECTION=postgresql://galaxy:chaopagoosaequuashie@postgres/galaxy
       - GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=${GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL:-http://localhost}

--- a/compose-v2/galaxy-configurator/templates/galaxy/job_conf.xml.j2
+++ b/compose-v2/galaxy-configurator/templates/galaxy/job_conf.xml.j2
@@ -8,29 +8,28 @@
             <param id="drmaa_library_path">/usr/lib/slurm-drmaa/lib/libdrmaa.so</param>
         </plugin>
     </plugins>
-    <destinations default="{{ GALAXY_JOB_DESTINATION|default('local') }}">
+    <destinations default="{{ GALAXY_DEPENDENCY_RESOLUTION | default('conda') }}_{{ GALAXY_JOB_RUNNER | default('local') }}">
         <destination id="local" runner="local">
             <env file="/galaxy/.venv/bin/activate" />
         </destination>
-        <destination id="condor" runner="condor">
-            <env file="/galaxy/.venv/bin/activate" />
+        <destination id="{{ GALAXY_DEPENDENCY_RESOLUTION | default('conda') }}_{{ GALAXY_JOB_RUNNER | default('local') }}" runner="{{ GALAXY_JOB_RUNNER | default('local') }}">
+            {% if GALAXY_DEPENDENCY_RESOLUTION == 'singularity' -%}
+              <env id="HOME">/home/galaxy</env>
+              <param id="singularity_enabled">true</param>
+              {% if GALAXY_JOB_RUNNER == 'local' -%}
+                <param id="singularity_volumes">{{ EXPORT_DIR | regex_replace("^.", "") }}/$galaxy_root:$galaxy_root:ro,{{ EXPORT_DIR | regex_replace("^.", "") }}/$tool_directory:$tool_directory:ro,{{ EXPORT_DIR | regex_replace("^.", "") }}/$job_directory:$job_directory:rw,{{ EXPORT_DIR | regex_replace("^.", "") }}/$working_directory:$working_directory:rw,{{ EXPORT_DIR | regex_replace("^.", "") }}/$default_file_path:$default_file_path:rw</param>
+              {% endif -%}
+            {% elif GALAXY_DEPENDENCY_RESOLUTION == 'docker' -%}
+              <param id="docker_enabled">true</param>
+              <param id="docker_sudo">false</param>
+              <param id="docker_set_user"></param>
+              {% if GALAXY_JOB_RUNNER == 'local' -%}
+                <param id="docker_volumes">{{ HOST_EXPORT_DIR }}/$galaxy_root:$galaxy_root:ro,{{ HOST_EXPORT_DIR }}/$tool_directory:$tool_directory:ro,{{ HOST_EXPORT_DIR }}/$job_directory:$job_directory:rw,{{ HOST_EXPORT_DIR }}/$working_directory:$working_directory:rw,{{ HOST_EXPORT_DIR }}/$default_file_path:$default_file_path:rw</param>
+              {% endif -%}
+            {% else -%}
+              <env file="/galaxy/.venv/bin/activate" />
+            {% endif -%}
         </destination>
-        <destination id="slurm" runner="slurm">
-            <env file="/galaxy/.venv/bin/activate" />
-        </destination>
-        {% if GALAXY_SINGULARTIY %}
-        <destination id="docker_local" runner="local">
-            <param id="docker_enabled">true</param>
-            <param id="docker_sudo">false</param>
-            <param id="docker_set_user"></param>
-            <param id="docker_volumes">{{ HOST_EXPORT_DIR }}/$galaxy_root:$galaxy_root:ro,{{ HOST_EXPORT_DIR }}/$tool_directory:$tool_directory:ro,{{ HOST_EXPORT_DIR }}/$job_directory:$job_directory:rw,{{ HOST_EXPORT_DIR }}/$working_directory:$working_directory:rw,{{ HOST_EXPORT_DIR }}/$default_file_path:$default_file_path:rw</param>
-        </destination>
-        <destination id="singularity_local" runner="local">
-            <env id="HOME">/home/galaxy</env>
-            <param id="singularity_enabled">true</param>
-            <param id="singularity_volumes">{{ EXPORT_DIR | regex_replace("^.", "") }}/$galaxy_root:$galaxy_root:ro,{{ EXPORT_DIR | regex_replace("^.", "") }}/$tool_directory:$tool_directory:ro,{{ EXPORT_DIR | regex_replace("^.", "") }}/$job_directory:$job_directory:rw,{{ EXPORT_DIR | regex_replace("^.", "") }}/$working_directory:$working_directory:rw,{{ EXPORT_DIR | regex_replace("^.", "") }}/$default_file_path:$default_file_path:rw</param>
-        </destination>
-        {% endif %}
     </destinations>
     <tools>
         <tool id="upload1" destination="local" />

--- a/compose-v2/galaxy-slurm/Dockerfile
+++ b/compose-v2/galaxy-slurm/Dockerfile
@@ -1,5 +1,35 @@
-FROM ubuntu:20.04 as final
+FROM buildpack-deps:18.04 as build_singularity
 
+ENV SINGULARITY_VERSION=3.5.3
+ENV GO_VERSION=1.13
+
+# Install Go (only needed for building singularity)
+RUN apt update && apt install --no-install-recommends cryptsetup-bin uuid-dev -y \
+    && wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzvf go${GO_VERSION}.linux-amd64.tar.gz \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz
+ENV PATH=/usr/local/go/bin:${PATH}
+
+RUN wget https://github.com/sylabs/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-${SINGULARITY_VERSION}.tar.gz \
+    && tar -xzf singularity-${SINGULARITY_VERSION}.tar.gz \
+    && cd singularity \
+    && ./mconfig \
+    && make -C builddir
+
+FROM ubuntu:18.04 as final
+
+ENV GALAXY_USER=galaxy \
+    GALAXY_GROUP=galaxy \
+    GALAXY_UID=1450 \
+    GALAXY_GID=1450 \
+    GALAXY_HOME=/home/galaxy
+
+RUN groupadd -r $GALAXY_USER -g $GALAXY_GID \
+    && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER \
+    && mkdir $GALAXY_HOME \
+    && chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_HOME
+
+# Install Slurm
 ENV SLURM_USER=galaxy \
     SLURM_UID=1450 \
     SLURM_GID=1450 \
@@ -7,13 +37,24 @@ ENV SLURM_USER=galaxy \
     MUNGE_UID=1200 \
     MUNGE_GID=1200
 
-RUN groupadd -r $SLURM_USER -g $SLURM_GID \
-    && useradd -u $SLURM_UID -r -g $SLURM_USER $SLURM_USER \
-    && groupadd -r $MUNGER_USER -g $MUNGE_GID \
+RUN groupadd -r $MUNGER_USER -g $MUNGE_GID \
     && useradd -u $MUNGE_UID -r -g $MUNGER_USER $MUNGER_USER \
     && apt update \
-    && apt install --no-install-recommends gosu munge python2 python2-dev slurm-wlm -y \
+    && apt install --no-install-recommends gosu munge python python-dev slurm-wlm -y \
     && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/*
+
+# Install Docker
+RUN apt update \
+    && apt install --no-install-recommends docker.io -y \
+    && usermod -aG docker $GALAXY_USER
+
+# Install Singularity
+COPY --from=build_singularity /singularity /singularity
+RUN apt update \
+    && apt install --no-install-recommends ca-certificates make squashfs-tools -y \
+    && make -C /singularity/builddir install \
+    && rm -rf /singularity \
+    && sed -e '/bind path = \/etc\/localtime/s/^/#/g' -i /usr/local/etc/singularity/singularity.conf
 
 COPY start.sh /usr/bin/start.sh
 


### PR DESCRIPTION
This PR allows to combine Slurm with Singularity. A simple `docker-compose -f docker-compose.yml -f docker-compose.slurm.yml -f docker-compose.singularity.yml up` is all thats needed.

To enable this, the configuration logic for `job_conf.xml` was enhanced, which allows to dynamically define the job_conf depending on the selected job runner and dependency resolution. So this change essentially enables to combine any job runner and dependency resolution in the future without much additional changes. Concrete usage change: Instead of setting `GALAXY_JOB_DESTINATION`, `GALAXY_JOB_RUNNER` and `GALAXY_DEPENDENCY_RESOLUTION` need to be defined, which is automatically handled in the docker-compose files.