### PR TITLE
Allow to run Singularity with HTCondor

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -91,6 +91,14 @@ jobs:
               - workflow_mapping_by_sequencing
               - workflow_GC-lite
               - selenium
+          - name: galaxy-htcondor-singularity
+            files: -f docker-compose.yml -f docker-compose.htcondor.yml -f docker-compose.singularity.yml
+            exclude_test:
+              - bioblend
+              - workflow_ard
+              - workflow_mapping_by_sequencing
+              - workflow_GC-lite
+              - selenium
         test:
           - name: bioblend
             files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.bioblend.yml

--- a/compose-v2/docker-compose.htcondor.yml
+++ b/compose-v2/docker-compose.htcondor.yml
@@ -12,6 +12,7 @@ services:
     image: ${IMAGE_DOMAIN:-andreassko}/galaxy-htcondor:${IMAGE_TAG:-latest}
     build: galaxy-htcondor
     hostname: htcondor-executor
+    privileged: true
     environment:
       - CONDOR_HOST=htcondor-master
     volumes:
@@ -21,6 +22,7 @@ services:
       - ${EXPORT_DIR:-./export}/galaxy/.venv:/galaxy/.venv
       - ${EXPORT_DIR:-./export}/tool_deps:/tool_deps
       - ./static_conf/htcondor_executor.conf:/etc/condor/condor_config.local:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - galaxy
   galaxy-server:

--- a/compose-v2/galaxy-htcondor/Dockerfile
+++ b/compose-v2/galaxy-htcondor/Dockerfile
@@ -1,12 +1,37 @@
-FROM ubuntu:19.10
+FROM buildpack-deps:18.04 as build_singularity
+
+ENV SINGULARITY_VERSION=3.5.3
+ENV GO_VERSION=1.13
+
+# Install Go (only needed for building singularity)
+RUN apt update && apt install --no-install-recommends cryptsetup-bin uuid-dev -y \
+    && wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzvf go${GO_VERSION}.linux-amd64.tar.gz \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz
+ENV PATH=/usr/local/go/bin:${PATH}
+
+RUN wget https://github.com/sylabs/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-${SINGULARITY_VERSION}.tar.gz \
+    && tar -xzf singularity-${SINGULARITY_VERSION}.tar.gz \
+    && cd singularity \
+    && ./mconfig \
+    && make -C builddir
+
+FROM ubuntu:18.04 as final
 
 ENV DEBIAN_FRONTEND noninteractive
 
 ENV GALAXY_USER=galaxy \
+    GALAXY_GROUP=galaxy \
     GALAXY_UID=1450 \
     GALAXY_GID=1450 \
-    GALAXY_HOME=/home/galaxy \
-    EXPORT_DIR=/export \
+    GALAXY_HOME=/home/galaxy
+
+RUN groupadd -r $GALAXY_USER -g $GALAXY_GID \
+    && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER \
+    && mkdir $GALAXY_HOME \
+    && chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_HOME
+
+ENV EXPORT_DIR=/export \
     # Setting a standard encoding. This can get important for things like the unix sort tool.
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8
@@ -28,18 +53,19 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup \
     && mkdir -p /var/run/condor/ /var/lock/condor/ \
     && chown -R condor: /var/log/condor/StartLog /var/log/condor/StarterLog /var/log/condor/CollectorLog /var/log/condor/NegotiatorLog /var/run/condor/ /var/lock/condor/
 
-# Condor executor
-RUN mkdir -p /tmp/download && \
-    wget --no-check-certificate -qO - https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz | tar -xz -C /tmp/download && \
-    mv /tmp/download/docker/docker /usr/bin/ && \
-    rm -rf /tmp/download && \
-    rm -rf ~/.cache/ && \
-    groupadd -r $GALAXY_USER -g $GALAXY_GID && \
-    useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" $GALAXY_USER && \
-    groupadd --gid 999 docker && \
-    gpasswd -a $GALAXY_USER docker && \
-    adduser condor docker
-
 ADD supervisord.conf /etc/supervisord.conf
+
+# Install Docker
+RUN apt update \
+    && apt install --no-install-recommends docker.io -y \
+    && usermod -aG docker $GALAXY_USER
+
+# Install Singularity
+COPY --from=build_singularity /singularity /singularity
+RUN apt update \
+    && apt install --no-install-recommends ca-certificates make squashfs-tools -y \
+    && make -C /singularity/builddir install \
+    && rm -rf /singularity \
+    && sed -e '/bind path = \/etc\/localtime/s/^/#/g' -i /usr/local/etc/singularity/singularity.conf
 
 ENTRYPOINT ["/usr/bin/supervisord"]


### PR DESCRIPTION
A simple `docker-compose -f docker-compose.yml -f docker-compose.htcondor.yml -f docker-compose.singularity.yml  up` is everything thats needed.

Changes to the HTCondor image:
* Downgrading Ubuntu version to 18.04 to be more streamlined with other containers (may reduce risk of incompatible libraries for shared venvs)
* Remove old install of Docker (legacy from v1 setup)
* Install Docker and Singularity (the same way as in Slurm and Galaxy)

Changes to the HTCondor docker-compose file:
* Made HTCondor executor privileged and mount docker.sock