### PR TITLE
Include parts of galaxy/lib into HTCondor and Slurm image

### DIFF
--- a/compose-v2/docker-compose.htcondor.yml
+++ b/compose-v2/docker-compose.htcondor.yml
@@ -18,7 +18,6 @@ services:
     volumes:
       - ${EXPORT_DIR:-./export}/galaxy/database:/galaxy/database
       - ${EXPORT_DIR:-./export}/galaxy/tools:/galaxy/tools:ro
-      - ${EXPORT_DIR:-./export}/galaxy/lib:/galaxy/lib:ro
       - ${EXPORT_DIR:-./export}/galaxy/.venv:/galaxy/.venv
       - ${EXPORT_DIR:-./export}/tool_deps:/tool_deps
       - ./static_conf/htcondor_executor.conf:/etc/condor/condor_config.local:ro

--- a/compose-v2/docker-compose.slurm.yml
+++ b/compose-v2/docker-compose.slurm.yml
@@ -38,7 +38,6 @@ services:
     volumes:
       - ${EXPORT_DIR:-./export}/galaxy/database:/galaxy/database
       - ${EXPORT_DIR:-./export}/galaxy/tools:/galaxy/tools:ro
-      - ${EXPORT_DIR:-./export}/galaxy/lib:/galaxy/lib:ro
       - ${EXPORT_DIR:-./export}/galaxy/.venv:/galaxy/.venv
       - ${EXPORT_DIR:-./export}/tool_deps:/tool_deps
       - ${EXPORT_DIR:-./export}/slurm_config:/etc/slurm-llnl

--- a/compose-v2/galaxy-htcondor/Dockerfile
+++ b/compose-v2/galaxy-htcondor/Dockerfile
@@ -16,6 +16,26 @@ RUN wget https://github.com/sylabs/singularity/releases/download/v${SINGULARITY_
     && ./mconfig \
     && make -C builddir
 
+
+FROM buildpack-deps:18.04 as galaxy_dependencies
+
+ARG GALAXY_RELEASE=release_19.09
+ARG GALAXY_REPO=https://github.com/galaxyproject/galaxy
+
+ENV GALAXY_ROOT=/galaxy
+ENV GALAXY_LIBRARY=$GALAXY_ROOT/lib
+
+# Download Galaxy source, but only keep necessary dependencies
+RUN mkdir "${GALAXY_ROOT}" \
+    && curl -L -s $GALAXY_REPO/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT \
+    && cd $GALAXY_ROOT \
+    && ls . | grep -v "lib" | xargs rm -rf \
+    && cd $GALAXY_ROOT/lib \
+    && ls . | grep -v "galaxy\|galaxy_ext" | xargs rm -rf \
+    && cd $GALAXY_ROOT/lib/galaxy \
+    && ls . | grep -v "__init__.py\|datatypes\|exceptions\|metadata\|model\|util\|security" | xargs rm -rf
+
+
 FROM ubuntu:18.04 as final
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -24,7 +44,8 @@ ENV GALAXY_USER=galaxy \
     GALAXY_GROUP=galaxy \
     GALAXY_UID=1450 \
     GALAXY_GID=1450 \
-    GALAXY_HOME=/home/galaxy
+    GALAXY_HOME=/home/galaxy \
+    GALAXY_ROOT=/galaxy
 
 RUN groupadd -r $GALAXY_USER -g $GALAXY_GID \
     && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER \
@@ -59,6 +80,9 @@ ADD supervisord.conf /etc/supervisord.conf
 RUN apt update \
     && apt install --no-install-recommends docker.io -y \
     && usermod -aG docker $GALAXY_USER
+
+# Copy Galaxy dependencies
+COPY --chown=$GALAXY_USER:$GALAXY_USER --from=galaxy_dependencies $GALAXY_ROOT $GALAXY_ROOT
 
 # Install Singularity
 COPY --from=build_singularity /singularity /singularity

--- a/compose-v2/galaxy-server/files/start.sh
+++ b/compose-v2/galaxy-server/files/start.sh
@@ -81,10 +81,6 @@ $GALAXY_ROOT/create_db.sh
 
 if [ -f "/etc/condor/condor_config.local" ]; then
     echo "HTCondor config file found"
-    echo "Copying Galaxy library to /export (needed by HTCondor workers).."
-    mkdir "$EXPORT_DIR/$GALAXY_ROOT/lib"
-    chown "$GALAXY_USER:$GALAXY_USER" "$EXPORT_DIR/$GALAXY_ROOT/lib"
-    cp -rpf $GALAXY_ROOT/lib/* $EXPORT_DIR/$GALAXY_ROOT/lib
     echo "Starting HTCondor.."
     service condor start
     # export CONDOR_CONFIG="/etc/condor/condor_config.local"

--- a/compose-v2/galaxy-slurm/Dockerfile
+++ b/compose-v2/galaxy-slurm/Dockerfile
@@ -16,13 +16,33 @@ RUN wget https://github.com/sylabs/singularity/releases/download/v${SINGULARITY_
     && ./mconfig \
     && make -C builddir
 
+
+FROM buildpack-deps:18.04 as galaxy_dependencies
+
+ARG GALAXY_RELEASE=release_19.09
+ARG GALAXY_REPO=https://github.com/galaxyproject/galaxy
+
+ENV GALAXY_ROOT=/galaxy
+
+# Download Galaxy source, but only keep necessary dependencies
+RUN mkdir "${GALAXY_ROOT}" \
+    && curl -L -s $GALAXY_REPO/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT \
+    && cd $GALAXY_ROOT \
+    && ls . | grep -v "lib" | xargs rm -rf \
+    && cd $GALAXY_ROOT/lib \
+    && ls . | grep -v "galaxy\|galaxy_ext" | xargs rm -rf \
+    && cd $GALAXY_ROOT/lib/galaxy \
+    && ls . | grep -v "__init__.py\|datatypes\|exceptions\|metadata\|model\|util\|security" | xargs rm -rf
+
+
 FROM ubuntu:18.04 as final
 
 ENV GALAXY_USER=galaxy \
     GALAXY_GROUP=galaxy \
     GALAXY_UID=1450 \
     GALAXY_GID=1450 \
-    GALAXY_HOME=/home/galaxy
+    GALAXY_HOME=/home/galaxy \
+    GALAXY_ROOT=/galaxy
 
 RUN groupadd -r $GALAXY_USER -g $GALAXY_GID \
     && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER \
@@ -47,6 +67,9 @@ RUN groupadd -r $MUNGER_USER -g $MUNGE_GID \
 RUN apt update \
     && apt install --no-install-recommends docker.io -y \
     && usermod -aG docker $GALAXY_USER
+
+# Copy Galaxy dependencies
+COPY --chown=$GALAXY_USER:$GALAXY_USER --from=galaxy_dependencies $GALAXY_ROOT $GALAXY_ROOT
 
 # Install Singularity
 COPY --from=build_singularity /singularity /singularity


### PR DESCRIPTION
To set the metadata, the worker nodes need the  `galaxy_ext` library and parts of `galaxy`, which earlier was not available to them. Instead of exporting it from Galaxy directly (which may result in degraded performance for the whole setup on Mac because of the shared filesystem), this change includes the library directly in the image. The size difference is minimal (< 5MB), so no problem there..

This should fix the following error:

> from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata() ImportError: No module named galaxy_ext.metadata.set_metadata