### PR TITLE
Add Pulsar with Message Queue to the setup

### DIFF
--- a/.github/workflows/compose-v2.yml
+++ b/.github/workflows/compose-v2.yml
@@ -82,6 +82,12 @@ jobs:
               - workflow_example1
               - workflow_mapping_by_sequencing
               - workflow_GC-lite
+          - name: galaxy-pulsar-mq
+            files: -f docker-compose.yml -f docker-compose.pulsar.yml -f docker-compose.pulsar.mq.yml
+            exclude_test:
+              - workflow_example1
+              - workflow_mapping_by_sequencing
+              - workflow_GC-lite
           - name: galaxy-singularity
             files: -f docker-compose.yml -f docker-compose.singularity.yml
             exclude_test:

--- a/compose-v2/docker-compose.pulsar.mq.yml
+++ b/compose-v2/docker-compose.pulsar.mq.yml
@@ -1,0 +1,23 @@
+# Extend Pulsar to use RabbitMQ (Message Queue) instead of the REST API
+# for communicating with Galaxy.
+# Requirements: `docker-compose.pulsar.yml`
+# Example: `docker-compose -f docker-compose.yml -f docker-compose.pulsar.yml -f docker-compose.pulsar.mq.yml up`
+version: "3"
+services:
+  galaxy-configurator:
+    environment:
+      - GALAXY_JOB_RUNNER=pulsar_mq
+      - PULSAR_CONFIG_MESSAGE_QUEUE_URL=amqp://pulsar:8jfqi9uo2i30fqoifqfo09@pulsar-rabbitmq/pulsar
+      - PULSAR_GALAXY_URL=http://nginx:80
+  pulsar-rabbitmq:
+    image: rabbitmq:alpine
+    container_name: pulsar-rabbitmq
+    hostname: pulsar-rabbitmq
+    environment:
+      - RABBITMQ_DEFAULT_USER=pulsar
+      - RABBITMQ_DEFAULT_PASS=8jfqi9uo2i30fqoifqfo09
+      - RABBITMQ_DEFAULT_VHOST=pulsar
+    volumes:
+      - ${EXPORT_DIR:-./export}/pulsar_rabbitmq:/var/lib/rabbitmq:delegated
+    networks:
+      - galaxy

--- a/compose-v2/galaxy-configurator/templates/galaxy/job_conf.xml.j2
+++ b/compose-v2/galaxy-configurator/templates/galaxy/job_conf.xml.j2
@@ -10,8 +10,11 @@
         <plugin id="pulsar_rest" type="runner" load="galaxy.jobs.runners.pulsar:PulsarRESTJobRunner"/>
         {% if GALAXY_JOB_RUNNER == 'pulsar_mq' -%}
         <plugin id="pulsar_mq" type="runner" load="galaxy.jobs.runners.pulsar:PulsarMQJobRunner">
-            <param id="galaxy_url">{{ galaxy.galaxy_infrastructure_url }}</param>
-            <param id="url">{{ GALAXY_PULSAR_MQ_URL }}</param>
+            <param id="galaxy_url">{{ PULSAR_GALAXY_URL }}</param>
+            <param id="amqp_url">{{ PULSAR_CONFIG_MESSAGE_QUEUE_URL}}</param>
+            <param id="amqp_acknowledge">True</param>
+            <param id="amqp_ack_republish_time">30</param>
+            <param id="amqp_publish_retry">True</param>
         </plugin>
         {% endif -%}
     </plugins>
@@ -40,6 +43,9 @@
               <param id="url">{{ GALAXY_PULSAR_URL }}</param>
               <param id="private_token">{{ PULSAR_CONFIG_PRIVATE_TOKEN }}</param>
               <param id="dependency_resolution">remote</param>
+            {% endif -%}
+            {% if GALAXY_JOB_RUNNER == 'pulsar_mq' -%}
+              <param id="jobs_directory">{{ PULSAR_JOBS_DIRECTORY | default('/pulsar/files/staging/') }}</param>
             {% endif -%}
         </destination>
     </destinations>

--- a/compose-v2/galaxy-configurator/templates/pulsar/server.ini.j2
+++ b/compose-v2/galaxy-configurator/templates/pulsar/server.ini.j2
@@ -36,11 +36,11 @@ keys = console
 keys = generic
 
 [logger_root]
-level = DEBUG
+level = INFO
 handlers = console
 
 [logger_pulsar]
-level = DEBUG
+level = INFO
 handlers = console
 qualname = pulsar
 propagate = 0
@@ -48,7 +48,7 @@ propagate = 0
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
-level = DEBUG
+level = INFO
 formatter = generic
 
 [formatter_generic]

--- a/compose-v2/pulsar/Dockerfile
+++ b/compose-v2/pulsar/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /tmp/pulsar \
     && pip3 install wheel \
     && python3 -m venv $PULSAR_VIRTUALENV \
     && . $PULSAR_VIRTUALENV/bin/activate \
-    && pip3 install drmaa kombu pastescript pastedeploy uwsgi \
+    && pip3 install drmaa kombu pastescript pastedeploy pycurl uwsgi \
     && cd /tmp/pulsar \
     && python3 /tmp/pulsar/setup.py install
 


### PR DESCRIPTION
With this setup, Galaxy and Pulsar are able to communicate using a message queue. For this, we add a second RabbitMQ container solely for Pulsar.

Example usage:

> docker-compose -f docker-compose.yml -f docker-compose.pulsar.yml -f docker-compose.pulsar.mq.yml up

Other small changes:
* Set Pulsar Log level from DEBUG to INFO